### PR TITLE
Fix dockerfile build path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM maven as build
 
 WORKDIR /build
-COPY src /build/
+COPY src /build/src
 COPY pom.xml /build/
 RUN mvn package
 


### PR DESCRIPTION
Currently I'm copying src/main to /build/main, we need to copy src/ to /build instead.